### PR TITLE
remove autogenerated url

### DIFF
--- a/roles/serverdensity/tasks/agent.yml
+++ b/roles/serverdensity/tasks/agent.yml
@@ -11,7 +11,7 @@
     repo: "{{ item }}"
     state: present
   with_items:
-    - "deb https://archive.serverdensity.com/{{ ansible_lsb.id | lower }}/ all main"
+    - "deb https://archive.serverdensity.com/ubuntu/ all main"
   when: ansible_os_family == "Debian"
 
 - name: Copy Server Density repository signing key (RedHat/CentOS)


### PR DESCRIPTION
We use `/ubuntu/` for both Ubuntu and Debian in the repository, so there's no need to auto generate the URL based on `ansible_lsb.id` and instead it should be fixed to `/ubuntu/`. 

@carlosperello please can you review? 