### PR TITLE
Attempt device lookup before creation

### DIFF
--- a/roles/serverdensity/tasks/agent.yml
+++ b/roles/serverdensity/tasks/agent.yml
@@ -68,15 +68,33 @@
     creates: /var/log/sd-agent-v2-install.log.json
   when: not upgraded.stat.exists and ansible_ec2_instance_id is undefined
 
-- name: Register device with the Server Density API - AWS
-  shell: curl -v -X POST https://api.serverdensity.io/inventory/devices/?token={{ api_token }} \
-         --data "name={{ sd_hostname | default(ansible_ec2_instance_id) }}" \
-         --data "group={{ group_name}}" \
-         --data "provider=amazon" \
-         --data "providerId={{ ansible_ec2_instance_id }}" > /var/log/sd-agent-v2-install.log.json
-  args:
-    creates: /var/log/sd-agent-v2-install.log.json
+- name: Attempt to lookup device with the Server Density API - AWS
+  uri:
+    url: https://api.serverdensity.io/inventory/resources?token={{ api_token }}&filter=%7b%22providerId%22%3a%22{{ ansible_ec2_instance_id }}%22%7d
+    status_code: 200
+    dest: /var/log/sd-agent-v2-install.log.json
+  register: http_response
   when: not upgraded.stat.exists and ansible_ec2_instance_id is defined
+
+- name: Remove from list
+  replace:
+    dest=/var/log/sd-agent-v2-install.log.json
+    regexp="{{ item.regexp }}"
+    replace="{{ item.replace }}"
+  with_items:
+    - { regexp: '^\[', replace: '' }
+    - { regexp: '\]$', replace: '' }
+  when: http_response.x_total_number > 0
+
+- name: Register device with the Server Density API - AWS
+  uri:
+    url: https://api.serverdensity.io/inventory/devices/?token={{ api_token }}
+    method: POST
+    body: "name={{ sd_hostname | default(ansible_ec2_instance_id) }}&group={{ group_name}}&provider=amazon&providerId={{ ansible_ec2_instance_id }}"
+    status_code: 200
+    dest: /var/log/sd-agent-v2-install.log.json
+    creates: /var/log/sd-agent-v2-install.log.json
+  when: not upgraded.stat.exists and ansible_ec2_instance_id is defined and http_response.x_total_number == "0"
 
 - name: Register JSON
   command: cat /var/log/sd-agent-v2-install.log.json

--- a/roles/serverdensity/tasks/agent.yml
+++ b/roles/serverdensity/tasks/agent.yml
@@ -60,21 +60,39 @@
     path: /var/log/sd-upgrade-v2-key.log.json
   register: upgraded
 
-- name: Register device with the Server Density API - non AWS
-  shell: curl -v -X POST https://api.serverdensity.io/inventory/devices/?token={{ api_token }} \
-         --data "name={{ sd_hostname | default(ansible_hostname) }}" \
-         --data "group={{ group_name}}" > /var/log/sd-agent-v2-install.log.json
-  args:
-    creates: /var/log/sd-agent-v2-install.log.json
+- name: Attempt to lookup device with the Server Density API - non AWS
+  uri:
+    url: https://api.serverdensity.io/inventory/resources?token={{ api_token }}&filter=%7b%22name%22%3a%22{{ sd_hostname | default(ansible_hostname) }}%22%7d
+    status_code: 200
+    dest: /var/log/sd-agent-v2-install.log.json
+  register: http_response
   when: not upgraded.stat.exists and ansible_ec2_instance_id is undefined
+
+- name: Register device with the Server Density API - non AWS
+  uri:
+    url: https://api.serverdensity.io/inventory/devices/?token={{ api_token }}
+    method: POST
+    body: "name={{ sd_hostname | default(ansible_hostname) }}&group={{ group_name}}"
+    status_code: 200
+    dest: /var/log/sd-agent-v2-install.log.json
+  when: not upgraded.stat.exists and ansible_ec2_instance_id is undefined and http_response.x_total_number == "0"
 
 - name: Attempt to lookup device with the Server Density API - AWS
   uri:
     url: https://api.serverdensity.io/inventory/resources?token={{ api_token }}&filter=%7b%22providerId%22%3a%22{{ ansible_ec2_instance_id }}%22%7d
     status_code: 200
     dest: /var/log/sd-agent-v2-install.log.json
-  register: http_response
+  register: aws_response
   when: not upgraded.stat.exists and ansible_ec2_instance_id is defined
+
+- name: Register device with the Server Density API - AWS
+  uri:
+    url: https://api.serverdensity.io/inventory/devices/?token={{ api_token }}
+    method: POST
+    body: "name={{ sd_hostname | default(ansible_ec2_instance_id) }}&group={{ group_name}}&provider=amazon&providerId={{ ansible_ec2_instance_id }}"
+    status_code: 200
+    dest: /var/log/sd-agent-v2-install.log.json
+  when: not upgraded.stat.exists and ansible_ec2_instance_id is defined and aws_response.x_total_number == "0"
 
 - name: Remove from list
   replace:
@@ -84,17 +102,8 @@
   with_items:
     - { regexp: '^\[', replace: '' }
     - { regexp: '\]$', replace: '' }
-  when: http_response.x_total_number > 0
+  when: (aws_response and aws_response.x_total_number is defined and aws_response.x_total_number > 0) or (http_response and http_response.x_total_number is defined and http_response.x_total_number > 0)
 
-- name: Register device with the Server Density API - AWS
-  uri:
-    url: https://api.serverdensity.io/inventory/devices/?token={{ api_token }}
-    method: POST
-    body: "name={{ sd_hostname | default(ansible_ec2_instance_id) }}&group={{ group_name}}&provider=amazon&providerId={{ ansible_ec2_instance_id }}"
-    status_code: 200
-    dest: /var/log/sd-agent-v2-install.log.json
-    creates: /var/log/sd-agent-v2-install.log.json
-  when: not upgraded.stat.exists and ansible_ec2_instance_id is defined and http_response.x_total_number == "0"
 
 - name: Register JSON
   command: cat /var/log/sd-agent-v2-install.log.json

--- a/roles/serverdensity/tasks/agent.yml
+++ b/roles/serverdensity/tasks/agent.yml
@@ -104,7 +104,6 @@
     - { regexp: '\]$', replace: '' }
   when: (aws_response and aws_response.x_total_number is defined and aws_response.x_total_number > 0) or (http_response and http_response.x_total_number is defined and http_response.x_total_number > 0)
 
-
 - name: Register JSON
   command: cat /var/log/sd-agent-v2-install.log.json
   register: result

--- a/roles/serverdensity/tasks/agent.yml
+++ b/roles/serverdensity/tasks/agent.yml
@@ -79,7 +79,7 @@
 
 - name: Attempt to lookup device with the Server Density API - AWS
   uri:
-    url: https://api.serverdensity.io/inventory/resources?token={{ api_token }}&filter=%7b%22providerId%22%3a%22{{ ansible_ec2_instance_id }}%22%7d
+    url: https://api.serverdensity.io/inventory/resources?token={{ api_token }}&filter=%7b%22providerId%22%3a%22{{ ansible_ec2_instance_id }}%22%2c%22provider%22%3a%22amazon%22%7d
     status_code: 200
     dest: /var/log/sd-agent-v2-install.log.json
   register: aws_response


### PR DESCRIPTION
This PR adds an api lookup to determine if the device has already been created in your Server Density account, based on the hostname (non-aws devices) or the providerId/instanceId (AWS devices). If the device is found then the returned agentkey is used, else a new device is created. 

This functionality has been added for AWS and non-AWS devices. 

@carlosperello please can you review? 