### PR TITLE
Amazon linux uses el6 repo

### DIFF
--- a/roles/serverdensity/files/serverdensity-amazon.repo
+++ b/roles/serverdensity/files/serverdensity-amazon.repo
@@ -1,0 +1,6 @@
+[server-density]
+name=Server Density Repository for Enterprise Linux 6
+baseurl=http://archive.serverdensity.com/el/6
+failovermethod=priority
+enabled=1
+gpgcheck=1

--- a/roles/serverdensity/tasks/agent.yml
+++ b/roles/serverdensity/tasks/agent.yml
@@ -27,14 +27,23 @@
   command: rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-serverdensity
   when: ansible_os_family == "RedHat"
 
-- name: Add server Density repository (RedHat/CentOS)
+- name: Add Server Density repository (RedHat/CentOS)
   copy:
     src: serverdensity.repo
     dest: /etc/yum.repos.d/serverdensity.repo
     owner: root
     group: root
     mode: 0644
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution != "Amazon"
+
+- name: Add Server Density repository (Amazon)
+  copy:
+    src: serverdensity-amazon.repo
+    dest: /etc/yum.repos.d/serverdensity.repo
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat"
 
 - name: Install/Update Server Density agent (Debian/Ubuntu)
   apt:


### PR DESCRIPTION
This PR sets the repository to el6 for Amazon linux. Tested on `Amazon Linux AMI release 2017.09` 

```
TASK [serverdensity : Add Server Density repository (RedHat/CentOS)] 
skipping: [localhost]

TASK [serverdensity : Add Server Density repository (Amazon)] 
changed: [localhost]
```
RedHat/CentOS repos are skipped and Amazon is used instead:
```
# cat /etc/yum.repos.d/serverdensity.repo 
[server-density]
name=Server Density Repository for Enterprise Linux 6
baseurl=http://archive.serverdensity.com/el/6
failovermethod=priority
enabled=1
gpgcheck=1
```

I also fixed the missing capital on Server Density as it was bugging me :)

@carlosperello please can you review? 