### PR TITLE
fix non-aws device lookup

### DIFF
--- a/roles/serverdensity/tasks/agent.yml
+++ b/roles/serverdensity/tasks/agent.yml
@@ -89,7 +89,7 @@
 
 - name: Attempt to lookup device with the Server Density API - non AWS
   uri:
-    url: https://api.serverdensity.io/inventory/resources?token={{ api_token }}&filter=%7b%22name%22%3a%22{{ sd_hostname | default(ansible_hostname) }}%22%7d
+    url: https://api.serverdensity.io/inventory/resources?token={{ api_token }}&filter=%7B%22name%22%3A%22{{ sd_hostname | default(ansible_hostname) }}%22%2C%20%22type%22%3A%20%22device%22%7D
     status_code: 200
     dest: /var/log/sd-agent-v2-install.log.json
   register: http_response


### PR DESCRIPTION
fixes the lookup filter so we don't return google volumes, and the json returned can be parsed correctly.